### PR TITLE
Reducing image size by another ~2mb

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,11 @@
 FROM alpine:latest
-RUN apk update
-RUN apk upgrade
-# RUN apk add bash nano
-# RUN apk add build-base
-# RUN apk add openssl
-# RUN apk add zlib
 
-# Tor 2.9.10 requires libevent-2.1
-# RUN apk add libevent --update-cache --repository http://dl-4.alpinelinux.org/alpine/edge/main/ --allow-untrusted
+RUN apk update \
+ && apk upgrade \
+ && apk add tor \
+ && rm /var/cache/apk/*
 
-# Alpine Linux package testing : http://dl-4.alpinelinux.org/alpine/edge/testing/x86_64/
-# RUN apk add tor --update-cache --repository http://dl-4.alpinelinux.org/alpine/edge/community/ --allow-untrusted
-RUN apk add tor
 EXPOSE 9150
-
-RUN rm /var/cache/apk/*
 
 ADD ./torrc /etc/tor/torrc
 


### PR DESCRIPTION
Removing apk's cache after committing the files into a layer has not the effect that you was probably hoping for. The files need to be removed before committing the layer..

This reduces the image size by another ~2mb :)